### PR TITLE
Add virtual text option for displaying detected version

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Example:
 vim.g.pnpm_catalog_display = "overlay"
 ```
 
+## Heighlight
+
+- `PnpmCatalogLensOverlay`: Display the detected version as virtual text overlay on the `catalog:`. It is useful when you want to see the version without moving the cursor.
+
 ## Credits
 
 Logo is from

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ return {
 | `PnpmCatalogLensEnable`  | Enable the lens  |
 | `PnpmCatalogLensDisable` | Disable the lens |
 
+## Configuration
+
+You can configure the display option for the detected version using the global variable `g:pnpm_catalog_display`. The available options are:
+
+- `diagnostics`: Display the detected version as diagnostics (default).
+- `overlay`: Display the detected version as virtual text overlay on the `catalog:`.
+
+Example:
+
+```lua
+vim.g.pnpm_catalog_display = "overlay"
+```
+
 ## Credits
 
 Logo is from

--- a/lua/pnpm_catalog_lens/constants.lua
+++ b/lua/pnpm_catalog_lens/constants.lua
@@ -6,4 +6,7 @@ local M = {
 	PACKAGE_JSON = "package.json",
 }
 
+-- Global variable for display option
+vim.g.pnpm_catalog_display = "diagnostics" -- options: "diagnostics" or "overlay"
+
 return M

--- a/lua/pnpm_catalog_lens/constants.lua
+++ b/lua/pnpm_catalog_lens/constants.lua
@@ -7,6 +7,8 @@ local M = {
 }
 
 -- Global variable for display option
-vim.g.pnpm_catalog_display = "diagnostics" -- options: "diagnostics" or "overlay"
+if vim.g.pnpm_catalog_display == nil then
+	vim.g.pnpm_catalog_display = "diagnostics" -- options: "diagnostics" or "overlay"
+end
 
 return M

--- a/lua/pnpm_catalog_lens/init.lua
+++ b/lua/pnpm_catalog_lens/init.lua
@@ -74,7 +74,7 @@ M.set_diagnostics = function()
 			end
 
 			if version ~= nil then
-				local text = version
+				local text = version .. string.rep(" ", #constants.CATALOG_PREFIX - #version)
 				api.nvim_buf_set_extmark(bufnr, ns, dep_info.line, dep_info.col - 1, {
 					virt_text = { { text, "Comment" } },
 					virt_text_pos = "overlay",

--- a/lua/pnpm_catalog_lens/init.lua
+++ b/lua/pnpm_catalog_lens/init.lua
@@ -56,7 +56,35 @@ M.set_diagnostics = function()
 		end
 	end
 
-	vim.diagnostic.set(ns, bufnr, diagnostics)
+	if vim.g.pnpm_catalog_display == "diagnostics" then
+		vim.diagnostic.set(ns, bufnr, diagnostics)
+	end
+
+	if vim.g.pnpm_catalog_display == "overlay" then
+		for dep, dep_info in pairs(catalog_deps) do
+			---@type string|nil
+			local version = nil
+			if dep_info.named ~= nil then
+				local named_catalog = (catalogs or {})[dep_info.named]
+				if named_catalog ~= nil then
+					version = named_catalog[dep]
+				end
+			else
+				version = (catalog or {})[dep]
+			end
+
+			if version ~= nil then
+				M.set_virtual_text(bufnr, dep_info.line, dep_info.col, version)
+			end
+		end
+	end
+end
+
+M.set_virtual_text = function(bufnr, line, col, text)
+	api.nvim_buf_set_extmark(bufnr, ns, line, col, {
+			virt_text = { { text, "Comment" } },
+			virt_text_pos = "overlay",
+	})
 end
 
 M.hide_lens = function()

--- a/lua/pnpm_catalog_lens/init.lua
+++ b/lua/pnpm_catalog_lens/init.lua
@@ -78,6 +78,7 @@ M.set_diagnostics = function()
 				api.nvim_buf_set_extmark(bufnr, ns, dep_info.line, dep_info.col - 1, {
 					virt_text = { { text, "Comment" } },
 					virt_text_pos = "overlay",
+					hl_group = "PnpmCatalogLensOverlay",
 				})
 			end
 		end

--- a/lua/pnpm_catalog_lens/init.lua
+++ b/lua/pnpm_catalog_lens/init.lua
@@ -74,7 +74,11 @@ M.set_diagnostics = function()
 			end
 
 			if version ~= nil then
-				M.set_virtual_text(bufnr, dep_info.line, dep_info.col, version)
+				local text = version
+				api.nvim_buf_set_extmark(bufnr, ns, dep_info.line, dep_info.col - 1, {
+					virt_text = { { text, "Comment" } },
+					virt_text_pos = "overlay",
+				})
 			end
 		end
 	end
@@ -82,8 +86,8 @@ end
 
 M.set_virtual_text = function(bufnr, line, col, text)
 	api.nvim_buf_set_extmark(bufnr, ns, line, col, {
-			virt_text = { { text, "Comment" } },
-			virt_text_pos = "overlay",
+		virt_text = { { text, "Comment" } },
+		virt_text_pos = "overlay",
 	})
 end
 


### PR DESCRIPTION
Fixes #2

Add option to display detected version in virtual text overlay.

* Add global variable `g:pnpm_catalog_display` with options "diagnostics" or "overlay" in `lua/pnpm_catalog_lens/constants.lua`.
* Modify `set_diagnostics` function in `lua/pnpm_catalog_lens/init.lua` to check the value of `g:pnpm_catalog_display` and display the detected version accordingly.
* Add new function `set_virtual_text` in `lua/pnpm_catalog_lens/init.lua` to display the detected version in virtual text overlay.
* Update `README.md` to include the new option for displaying the detected version in virtual text overlay.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ryoppippi/nvim-pnpm-catalog-lens/issues/2?shareId=197c7b8e-ac68-4ec0-9d3b-689b30056662).