### PR TITLE
feat: support yarn catalogs

### DIFF
--- a/lua/pnpm_catalog_lens/api.lua
+++ b/lua/pnpm_catalog_lens/api.lua
@@ -27,11 +27,21 @@ end
 
 M.find_pnpm_workspace = function()
 	local cwd = vim.fn.getcwd()
-	local root_dir = fs.root(cwd, vim.iter({ ".git", constants.PNPM_WORKSPACE }):flatten(math.huge):totable())
+	local root_dir = fs.root(
+		cwd,
+		vim.iter({ ".git", constants.PNPM_WORKSPACE, constants.YARN_WORKSPACE }):flatten(math.huge):totable()
+	)
 
-	local pnpm_workspace_path = fs.joinpath(root_dir or "", constants.PNPM_WORKSPACE)
-	if root_dir ~= nil and uv.fs_stat(pnpm_workspace_path) ~= nil then
-		return pnpm_workspace_path
+	if root_dir ~= nil then
+		local pnpm_workspace_path = fs.joinpath(root_dir or "", constants.PNPM_WORKSPACE)
+		if uv.fs_stat(pnpm_workspace_path) ~= nil then
+			return pnpm_workspace_path
+		end
+
+		local yarn_workspace_path = fs.joinpath(root_dir or "", constants.YARN_WORKSPACE)
+		if uv.fs_stat(yarn_workspace_path) ~= nil then
+			return yarn_workspace_path
+		end
 	end
 
 	return nil

--- a/lua/pnpm_catalog_lens/constants.lua
+++ b/lua/pnpm_catalog_lens/constants.lua
@@ -2,6 +2,7 @@
 local M = {
 	NAME = "pnpm-catalog-lens",
 	PNPM_WORKSPACE = "pnpm-workspace.yaml",
+	YARN_WORKSPACE = ".yarnrc.yml",
 	CATALOG_PREFIX = "catalog:",
 	PACKAGE_JSON = "package.json",
 }


### PR DESCRIPTION
Hello :) Thank you for creating this useful plugin. As a Yarn user, I thought it would be great if this plugin could support Yarn catalogs. The VSCode extension that inspired this plugin (https://github.com/antfu/vscode-pnpm-catalog-lens) now supports not only pnpm but also Yarn and Bun catalogs.

I've modified the workspace detection logic to check for `.yarnrc.yml` in addition to `pnpm-workspace.yaml` to enable Yarn catalog support. Yarn catalogs are defined in the `.yarnrc.yml` file at the project root using the same format as pnpm. For more details, please refer to this documentation: https://yarnpkg.com/features/catalogs

| pnpm (diagnostics) | yarn (diagnostics) |
|--|--|
| <img width="350" alt="SCR-20251016-szwt" src="https://github.com/user-attachments/assets/1fed5fcb-a962-437a-aa55-1fb95308e3fa" /> | <img width="350" alt="SCR-20251016-szro" src="https://github.com/user-attachments/assets/0af2bab1-b478-4d1f-af37-3a75d544a0d6" /> |

| pnpm (overlay) | yarn (overlay) |
|--|--|
| <img width="350" alt="SCR-20251016-szhc" src="https://github.com/user-attachments/assets/1d95d988-247a-4ace-bee5-b3196f2d8ca7" /> | <img width="350" alt="SCR-20251016-szon" src="https://github.com/user-attachments/assets/2659bdb0-60e4-4f08-9cbf-0bc6c3ef04bf" /> |

To avoid introducing breaking changes and minimize modifications, I haven't removed the "pnpm" string from the plugin name or API names.