### PR TITLE
feat(display): add inlay hint display mode

### DIFF
--- a/lua/pnpm_catalog_lens/constants.lua
+++ b/lua/pnpm_catalog_lens/constants.lua
@@ -8,7 +8,7 @@ local M = {
 
 -- Global variable for display option
 if vim.g.pnpm_catalog_display == nil then
-	vim.g.pnpm_catalog_display = "diagnostics" -- options: "diagnostics" or "overlay"
+	vim.g.pnpm_catalog_display = "diagnostics" -- options: "diagnostics", "overlay", or "inlay"
 end
 
 return M

--- a/lua/pnpm_catalog_lens/init.lua
+++ b/lua/pnpm_catalog_lens/init.lua
@@ -83,6 +83,28 @@ M.set_diagnostics = function()
 			end
 		end
 	end
+
+	if vim.g.pnpm_catalog_display == "inlay" then
+		for dep, dep_info in pairs(catalog_deps) do
+			---@type string|nil
+			local version = nil
+			if dep_info.named ~= nil then
+				local named_catalog = (catalogs or {})[dep_info.named]
+				if named_catalog ~= nil then
+					version = named_catalog[dep]
+				end
+			else
+				version = (catalog or {})[dep]
+			end
+
+			if version ~= nil then
+				api.nvim_buf_set_extmark(bufnr, ns, dep_info.line, 0, {
+					virt_text = { { " " .. version, "LspInlayHint" } },
+					virt_text_pos = "eol",
+				})
+			end
+		end
+	end
 end
 
 M.set_virtual_text = function(bufnr, line, col, text)


### PR DESCRIPTION
## Summary

Add a new "inlay" display mode that shows version information at the end of lines using the `LspInlayHint` highlight group.

## What Changed

- Added `"inlay"` as a third display option alongside `"diagnostics"` and `"overlay"`
- Uses `virt_text_pos = "eol"` to display versions at line endings
- Styled with `LspInlayHint` highlight group for consistency with LSP inlay hints

## Usage

```lua
vim.g.pnpm_catalog_display = "inlay"
```